### PR TITLE
Added 'away_only' mode to introduce new behaviour: pushing bullets only when away.

### DIFF
--- a/pbnotifications.pl
+++ b/pbnotifications.pl
@@ -43,23 +43,26 @@ my $curl = WWW::Curl::Easy->new;
 my ($pb_key, $pb_device);
 my $cooldown;
 my $pb_pernick;
+my $away_only;
 my %nick_ts;
 
 sub initialize {
     Irssi::settings_add_str("pbnotifications", "pb_key", "");
     Irssi::settings_add_int("pbnotifications", "pb_cooldown", 0);
     Irssi::settings_add_bool("pbnotifications", "pb_pernick", 1);
+    Irssi::settings_add_bool("pbnotifications", "away_only", 1);
 
     $pb_key = Irssi::settings_get_str("pb_key");
     $cooldown = Irssi::settings_get_int("pb_cooldown");
     $pb_pernick = Irssi::settings_get_bool("pb_pernick");
+    $away_only = Irssi::settings_get_bool("away_only");
 
     Irssi::settings_add_str("pbnotifications", "pb_device", "");
     $pb_device = Irssi::settings_get_str("pb_device");
 }
 
 sub _push {
-    unless ( Irssi::active_win->{'active_server'}->{usermode_away} == 0 ) {
+    if ( $away_only = 1 ) { return unless ( Irssi::active_win->{'active_server'}->{usermode_away} == 1 ) }
     my $params = shift;
     my %options = %$params;;
     my $options_str = "device_iden=$pb_device";
@@ -86,7 +89,6 @@ sub _push {
     #     return 0;
     # }
     # return 1;
-    }
 }
 
 sub _cooldown {

--- a/pbnotifications.pl
+++ b/pbnotifications.pl
@@ -50,7 +50,7 @@ sub initialize {
     Irssi::settings_add_str("pbnotifications", "pb_key", "");
     Irssi::settings_add_int("pbnotifications", "pb_cooldown", 0);
     Irssi::settings_add_bool("pbnotifications", "pb_pernick", 1);
-    Irssi::settings_add_bool("pbnotifications", "away_only", 1);
+    Irssi::settings_add_bool("pbnotifications", "away_only", 0);
 
     $pb_key = Irssi::settings_get_str("pb_key");
     $cooldown = Irssi::settings_get_int("pb_cooldown");

--- a/pbnotifications.pl
+++ b/pbnotifications.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-$VERSION = "201502a";
+$VERSION = "201502b";
 
 # Simple script to push notifications and mentions to PushBullet
 #

--- a/pbnotifications.pl
+++ b/pbnotifications.pl
@@ -59,6 +59,7 @@ sub initialize {
 }
 
 sub _push {
+    unless ( Irssi::active_win->{'active_server'}->{usermode_away} == 0 ) {
     my $params = shift;
     my %options = %$params;;
     my $options_str = "device_iden=$pb_device";
@@ -85,6 +86,7 @@ sub _push {
     #     return 0;
     # }
     # return 1;
+    }
 }
 
 sub _cooldown {


### PR DESCRIPTION
Best used in conjunction with 'awayproxy.pl', which is what I do so that I get no bullets pushed whenever any of my clients is connected to the proxy running this script e.g. when I'm active.
